### PR TITLE
softmax_locality pipeline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "poprox-recommender",
+  "name": "poprox-recommender-locality",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/poprox_recommender/components/diversifiers/locality_calibration.py
+++ b/src/poprox_recommender/components/diversifiers/locality_calibration.py
@@ -1,19 +1,33 @@
+import logging
+from collections import defaultdict
+
 import torch as th
 
-from poprox_concepts import ArticleSet, InterestProfile
+from poprox_concepts import Article, ArticleSet, InterestProfile
 from poprox_recommender.components.diversifiers.calibration import Calibrator
+from poprox_recommender.components.samplers import SoftmaxSampler
 from poprox_recommender.topics import extract_locality, normalized_category_count
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 
 # Locality Calibration uses MMR
 # to rerank recommendations according to
 # locality calibration
 class LocalityCalibrator(Calibrator):
-    def __init__(self, theta: float = 0.1, num_slots=10):
+    def __init__(self, theta: float = 0.1, num_slots=10):  # , scorer=None):
         super().__init__(theta, num_slots)
+        # add a different scorer than NMRS. Theta
+        self.scorer = SoftmaxSampler(num_slots=num_slots, temperature=30.0)
 
     def __call__(self, candidate_articles: ArticleSet, interest_profile: InterestProfile) -> ArticleSet:
-        normalized_locality_prefs = normalized_category_count(interest_profile.click_locality_counts)
+        if self.scorer is not None:
+            candidate_articles = self.scorer.sort_score(candidate_articles)
+        normalized_locality_prefs = normalized_category_count(
+            self.article_locality_distribution(candidate_articles.articles)
+        )
+        logger.info(f"nomarlized locality distribution of canidate articles: {normalized_locality_prefs}")
 
         if candidate_articles.scores is not None:
             article_scores = th.sigmoid(th.tensor(candidate_articles.scores))
@@ -29,9 +43,22 @@ class LocalityCalibrator(Calibrator):
             self.theta,
             topk=self.num_slots,
         )
+        # new_calibrated_indicies = [idx for idx in article_indices if idx >= self.num_slots]
+        logger.info(f"Articles added as a results of calibration: {article_indices}")
+
         return ArticleSet(articles=[candidate_articles.articles[int(idx)] for idx in article_indices])
 
     def add_article_to_categories(self, rec_categories, article):
         locality_list = extract_locality(article)
         for locality in locality_list:
             rec_categories[locality] = rec_categories.get(locality, 0) + 1
+
+    def article_locality_distribution(self, articles: list[Article]):
+        locality_count_dict = defaultdict(int)
+
+        for article in articles:
+            article_locality = extract_locality(article)
+            for locality in article_locality:
+                locality_count_dict[locality] += 1
+
+        return locality_count_dict

--- a/src/poprox_recommender/components/samplers/softmax.py
+++ b/src/poprox_recommender/components/samplers/softmax.py
@@ -8,7 +8,7 @@ class SoftmaxSampler:
         self.num_slots = num_slots
         self.temperature = temperature
 
-    def __call__(self, candidate_articles: ArticleSet):
+    def sort_score(self, candidate_articles: ArticleSet):
         if candidate_articles.scores is None:
             scores = np.ones(len(candidate_articles.articles))
         else:
@@ -38,9 +38,15 @@ class SoftmaxSampler:
 
         # This is just bookkeeping to produce the final ordered list of recs
         sorted_indices = np.argsort(exponentials)
-        sampled = [candidate_articles.articles[idx] for idx in sorted_indices[: self.num_slots]]
 
-        return ArticleSet(articles=sampled)
+        candidate_articles.articles = [candidate_articles.articles[idx] for idx in sorted_indices]
+        candidate_articles.scores = [exponentials[idx] for idx in sorted_indices]
+        return candidate_articles
+
+    def __call__(self, candidate_articles: ArticleSet):
+        sorted_articles = self.sort_score(candidate_articles)
+
+        return ArticleSet(articles=sorted_articles.articles[: self.num_slots])
 
 
 def sigmoid(x):

--- a/src/poprox_recommender/recommenders.py
+++ b/src/poprox_recommender/recommenders.py
@@ -93,6 +93,7 @@ def build_pipelines(num_slots: int, device: str) -> dict[str, Pipeline]:
     locality_calibrator = LocalityCalibrator(num_slots=num_slots)
     topic_calibrator = TopicCalibrator(num_slots=num_slots)
     sampler = SoftmaxSampler(num_slots=num_slots, temperature=30.0)
+    softmax_locality_calibrator = LocalityCalibrator(theta=0.5, num_slots=num_slots)  # , scorer=sampler)
 
     nrms_pipe = build_pipeline(
         "plain-NRMS",
@@ -134,6 +135,14 @@ def build_pipelines(num_slots: int, device: str) -> dict[str, Pipeline]:
         num_slots=num_slots,
     )
 
+    softmax_locality_cali_pipe = build_pipeline(
+        "NRMS+Softmax+Locality+Calibration",
+        article_embedder=article_embedder,
+        user_embedder=user_embedder,
+        ranker=softmax_locality_calibrator,
+        num_slots=num_slots,
+    )
+
     softmax_pipe = build_pipeline(
         "NRMS+Softmax",
         article_embedder=article_embedder,
@@ -149,6 +158,7 @@ def build_pipelines(num_slots: int, device: str) -> dict[str, Pipeline]:
         "topic-cali": topic_cali_pipe,
         "locality-cali": locality_cali_pipe,
         "softmax": softmax_pipe,
+        "softmax-locality-cali": softmax_locality_cali_pipe,
     }
 
 


### PR DESCRIPTION
A new pipeline to support the aforementioned softmax + locality cali method.

Also added changes to the softmax sampler to support calculating probability scores outside of the call function.

Creating a PR to discuss these points further:

 Does it make sense to layer calibration over softmax? Probability score + calibration???
 I had issues with pydantic serialization of the softmax sampler. Current implementation is hard coded with commented-out variables.
 Test with local API demonstrated no overlap. We should talk about more options for experimentation without sample data.