### PR TITLE
Add generic poprox export support to generate.py

### DIFF
--- a/outputs/.gitignore
+++ b/outputs/.gitignore
@@ -4,3 +4,4 @@
 /mind-val-user-metrics.csv.gz
 /mind-small-recommendations.parquet
 /mind-small-user-metrics.csv.gz
+/poprox.parquet

--- a/src/poprox_recommender/components/diversifiers/locality_calibration.py
+++ b/src/poprox_recommender/components/diversifiers/locality_calibration.py
@@ -16,7 +16,8 @@ from poprox_recommender.topics import extract_general_topics, extract_locality, 
 class LocalityCalibrator(Component):
     def __init__(self, theta_local: float = 0.1, theta_topic: float = 0.1, num_slots=10):
         """
-        TODOs: If set different theta_topic and theta_local values for different users, then can save them in interest_profile
+        TODOs: If set different theta_topic and theta_local values for different users,
+        then can save them in interest_profile
         """
         self.theta_local = theta_local
         self.theta_topic = theta_topic

--- a/src/poprox_recommender/components/diversifiers/locality_calibration.py
+++ b/src/poprox_recommender/components/diversifiers/locality_calibration.py
@@ -38,7 +38,7 @@ class LocalityCalibrator(Component):
             candidate_articles.articles,
             normalized_topic_prefs,
             normalized_locality_prefs,
-            theta_topic,
+            self.theta_topic,
             self.theta_local,
             topk=self.num_slots,
         )

--- a/src/poprox_recommender/data/data.py
+++ b/src/poprox_recommender/data/data.py
@@ -1,0 +1,12 @@
+from typing import Generator
+
+from poprox_concepts.api.recommendations import RecommendationRequest
+
+
+class Data:
+    @property
+    def n_users(self) -> int:
+        pass
+
+    def iter_users(self) -> Generator[RecommendationRequest, None, None]:
+        pass

--- a/src/poprox_recommender/data/mind.py
+++ b/src/poprox_recommender/data/mind.py
@@ -16,13 +16,14 @@ import pandas as pd
 
 from poprox_concepts import Article, Click, InterestProfile
 from poprox_concepts.api.recommendations import RecommendationRequest
+from poprox_recommender.data.data import Data
 from poprox_recommender.paths import project_root
 
 logger = logging.getLogger(__name__)
 TEST_REC_COUNT = 10
 
 
-class MindData:
+class MindData(Data):
     """
     News and behavior data loaded from MIND data.
     """

--- a/src/poprox_recommender/data/poprox.py
+++ b/src/poprox_recommender/data/poprox.py
@@ -1,0 +1,41 @@
+"""
+Support for loading POPROX data for evaluation.
+
+"""
+
+import json
+import logging
+import os
+from typing import Generator
+
+from poprox_concepts.api.recommendations import RecommendationRequest
+from poprox_recommender.data.data import Data
+
+logger = logging.getLogger(__name__)
+TEST_REC_COUNT = 10
+
+
+class PoproxData(Data):
+    def __init__(self, folder_path: str):
+        self.folder_path = folder_path
+
+    @property
+    def n_users(self) -> int:
+        # Count the number of JSON files in the folder path
+        return sum(1 for filename in os.listdir(self.folder_path) if filename.endswith(".json"))
+
+    def iter_users(self) -> Generator[RecommendationRequest, None, None]:
+        for filename in os.listdir(self.folder_path):
+            if filename.endswith(".json"):
+                file_path = os.path.join(self.folder_path, filename)
+
+                with open(file_path, "r") as file:
+                    data = json.load(file)
+
+                # yield RecommendationRequest.model_validate_json(data)
+                yield RecommendationRequest(
+                    todays_articles=data.get("todays_articles"),
+                    past_articles=data.get("past_articles"),
+                    interest_profile=data.get("interest_profile"),
+                    num_recs=data.get("num_recs"),
+                )

--- a/src/poprox_recommender/evaluation/generate.py
+++ b/src/poprox_recommender/evaluation/generate.py
@@ -163,6 +163,7 @@ if __name__ == "__main__":
     """
     For offline evaluation, set theta in mmr_diversity = 1
     """
+    print("in poprox-recommender-locality")
     options = docopt(__doc__)  # type: ignore
     setup_logging(verbose=options["--verbose"], log_file=options["--log-file"])
 

--- a/src/poprox_recommender/handler.py
+++ b/src/poprox_recommender/handler.py
@@ -3,10 +3,9 @@ import logging
 
 from poprox_concepts import ArticleSet
 from poprox_concepts.api.recommendations import RecommendationRequest, RecommendationResponse
+from poprox_recommender.components.diversifiers.locality_calibration import generated_context
 from poprox_recommender.recommenders import select_articles
 from poprox_recommender.topics import user_topic_preference
-from poprox_recommender.components.diversifiers.locality_calibration import generated_context
-
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)

--- a/src/poprox_recommender/recommenders.py
+++ b/src/poprox_recommender/recommenders.py
@@ -143,7 +143,7 @@ def build_pipelines(num_slots: int, device: str) -> dict[str, Pipeline]:
     )
 
     return {
-        "nrms": locality_cali_pipe,
+        "nrms": nrms_pipe,
         "mmr": mmr_pipe,
         "pfar": pfar_pipe,
         "topic-cali": topic_cali_pipe,

--- a/src/poprox_recommender/recommenders.py
+++ b/src/poprox_recommender/recommenders.py
@@ -84,8 +84,8 @@ def build_pipelines(num_slots: int, device: str) -> dict[str, Pipeline]:
         num_slots: The number of items to recommend.
     """
 
-    article_embedder = NRMSArticleEmbedder(model_file_path("nrms-mind/news_encoder.safetensors"), device)
-    user_embedder = NRMSUserEmbedder(model_file_path("nrms-mind/user_encoder.safetensors"), device)
+    article_embedder = NRMSArticleEmbedder(model_file_path("news_encoder.safetensors"), device)
+    user_embedder = NRMSUserEmbedder(model_file_path("user_encoder.safetensors"), device)
 
     topk_ranker = TopkRanker(num_slots=num_slots)
     mmr = MMRDiversifier(num_slots=num_slots)


### PR DESCRIPTION
Adding support for generic data_path to generate.py

To use, add poprox_recommender module to path variables. Then...

Usage: python -m poprox_recommender.evaluation.generate --data_path ../request_per_user -o outputs/poprox.parquet --pipelines=locality-cali

For multiple pipelines: Usage: python -m poprox_recommender.evaluation.generate --data_path ../request_per_user -o outputs/poprox.parquet --pipelines=locality-cali --pipelines=topic-cali


Noticed a weird behavior with the typing export wanting Generator[RecommendationRequest, **None, None**]