### PR TITLE
Extract context generation to a new `ContextGenerator` component and add it to the pipeline

### DIFF
--- a/src/poprox_recommender/components/generators/context.py
+++ b/src/poprox_recommender/components/generators/context.py
@@ -1,0 +1,142 @@
+from datetime import datetime
+
+import numpy as np
+from openai import OpenAI
+from sentence_transformers import SentenceTransformer
+from sklearn.metrics.pairwise import cosine_similarity
+
+from poprox_concepts import Article, ArticleSet
+from poprox_recommender.lkpipeline import Component
+from poprox_recommender.topics import extract_general_topics
+
+model = SentenceTransformer("all-MiniLM-L6-v2")
+
+client = OpenAI(
+    api_key="Put your key here",
+)
+
+
+class ContextGenerator(Component):
+    def __init__(self, text_generation=False, time_decay=True, topk_similar=5, other_filter="topic"):
+        self.text_generation = text_generation
+        self.time_decay = time_decay
+        self.topk_similar = topk_similar
+        self.other_filter = other_filter
+
+    def __call__(self, clicked: ArticleSet, recommended: ArticleSet) -> ArticleSet:
+        for article in recommended.articles:
+            generated_subhead = generated_context(
+                article, clicked, self.time_decay, self.topk_similar, self.other_filter
+            )
+            article.subhead = generated_subhead
+
+        return recommended
+
+
+def generated_context(
+    article: Article, clicked_articles: ArticleSet, time_decay: bool, topk_similar: int, other_filter: str | None = None
+):
+    # TODO: add fallback that based on user interests
+
+    topk_similar = min(topk_similar, len(clicked_articles.articles))
+    related_articles = related_context(article, clicked_articles, time_decay, topk_similar, other_filter)
+
+    input_prompt = []
+    input_prompt.append({"ID": "Main News", "subhead": article.subhead})
+
+    for i in range(topk_similar):
+        input_prompt.append({"ID": "Related News", "subhead": related_articles[i].subhead})
+
+    generated_subhead = generate_narrative(input_prompt)
+    return generated_subhead
+
+
+def related_context(
+    article: Article, clicked: ArticleSet, time_decay: bool, topk_similar: int, other_filter: str | None = None
+):
+    selected_subhead = article.subhead
+    selected_date = article.published_at
+    selected_topic = extract_general_topics(article)
+
+    if other_filter == "topic":
+        filtered_candidates = [
+            candidate for candidate in clicked.articles if set(extract_general_topics(candidate)) & set(selected_topic)
+        ]
+        clicked_articles = filtered_candidates if filtered_candidates else clicked.articles
+
+    else:
+        clicked_articles = clicked.articles
+
+    candidate_indices = related_indices(selected_subhead, selected_date, clicked_articles, time_decay, topk_similar)
+
+    return [clicked_articles[index] for index in candidate_indices]
+
+
+def related_indices(
+    selected_subhead: str, selected_date: datetime, clicked_articles: list, time_decay: bool, topk_similar: int
+):
+    all_subheads = [selected_subhead] + [article.subhead for article in clicked_articles]
+    embeddings = model.encode(all_subheads)
+
+    target_embedding = embeddings[0].reshape(1, -1)
+    clicked_embeddings = embeddings[1:]
+    similarities = cosine_similarity(target_embedding, clicked_embeddings)[0]
+
+    if time_decay:
+        weights = [
+            get_time_weight(selected_date, published_date)
+            for published_date in [article.published_at for article in clicked_articles]
+        ]
+        weighted_similarities = similarities * weights
+        return np.argsort(weighted_similarities)[-topk_similar:][::-1]
+
+    return np.argsort(similarities)[-topk_similar:][::-1]
+
+
+def generate_narrative(news_list):
+    system_prompt = (
+        "You are a personalized text generator."
+        " First, i will provide you with a news list that"
+        " includes both the [Main News] and [Related News]."
+        " Based on the input news list and user interests,"
+        " please generate a new personalized news summary centered around the [Main News]."
+    )
+
+    input_prompt = "News List: \n" + f"{news_list}"
+    return gpt_generate(system_prompt, input_prompt)
+
+
+def get_time_weight(published_target, published_clicked):
+    time_distance = abs((published_clicked - published_target).days)
+    weight = 1 / np.log(1 + time_distance) if time_distance > 0 else 1  # Avoid log(1) when x = 0
+    return weight
+
+
+###################### text generation part
+def gpt_generate(system_prompt, content_prompt):
+    message = [{"role": "system", "content": system_prompt}, {"role": "user", "content": content_prompt}]
+    temperature = 0.2
+    max_tokens = 512
+    frequency_penalty = 0.0
+
+    chat_completion = client.chat.completions.create(
+        messages=message,
+        temperature=temperature,
+        max_tokens=max_tokens,
+        frequency_penalty=frequency_penalty,
+        model="gpt-4o-mini",
+    )
+    return chat_completion.choices[0].message.content
+
+
+"""
+# TODO: check backward or forward for past k articles
+def user_interest_generate(past_articles: Article, past_k: int):
+    system_prompt = (
+        "You are asked to describe user interest based on his/her browsed news list."
+        " User interest includes the news [categories] and news [topics]"
+        " (under each [category] that users are interested in."
+    )
+
+    return gpt_generate(system_prompt, f"{past_article_infor}")
+"""

--- a/src/poprox_recommender/handler.py
+++ b/src/poprox_recommender/handler.py
@@ -3,7 +3,6 @@ import logging
 
 from poprox_concepts import ArticleSet
 from poprox_concepts.api.recommendations import RecommendationRequest, RecommendationResponse
-from poprox_recommender.components.diversifiers.locality_calibration import generated_context
 from poprox_recommender.recommenders import select_articles
 from poprox_recommender.topics import user_topic_preference
 
@@ -58,16 +57,6 @@ def generate_recs(event, context):
         profile,
         pipeline_params,
     )
-
-    text_generation = False  # TODO: move to parameter
-    time_decay = True  # TODO: move to parameter
-    topk_similar = 5  # TODO: move to parameter
-    other_filter = "topic"  # TODO: move to parameter
-
-    if text_generation:
-        for article in outputs.default.articles:
-            generated_subhead = generated_context(article, clicked_articles, time_decay, topk_similar, other_filter)
-            article.subhead = generated_subhead
 
     logger.info("Constructing response...")
     resp_body = RecommendationResponse.model_validate(

--- a/src/poprox_recommender/recommenders.py
+++ b/src/poprox_recommender/recommenders.py
@@ -11,6 +11,7 @@ from poprox_recommender.components.diversifiers import (
 )
 from poprox_recommender.components.embedders import NRMSArticleEmbedder, NRMSUserEmbedder
 from poprox_recommender.components.filters import TopicFilter
+from poprox_recommender.components.generators.context import ContextGenerator
 from poprox_recommender.components.joiners import Fill
 from poprox_recommender.components.rankers.topk import TopkRanker
 from poprox_recommender.components.samplers import SoftmaxSampler, UniformSampler
@@ -158,6 +159,7 @@ def build_pipeline(name, article_embedder, user_embedder, ranker, num_slots):
     sampler = UniformSampler(num_slots=num_slots)
     fill = Fill(num_slots=num_slots)
     topk_ranker = TopkRanker(num_slots=num_slots)
+    generator = ContextGenerator()
 
     pipeline = Pipeline(name=name)
 
@@ -166,10 +168,6 @@ def build_pipeline(name, article_embedder, user_embedder, ranker, num_slots):
     clicked = pipeline.create_input("clicked", ArticleSet)
     profile = pipeline.create_input("profile", InterestProfile)
 
-    # locality-calibration specific inputs
-    theta_topic = pipeline.create_input("theta_topic", float)
-    theta_locality = pipeline.create_input("theta_locality", float)
-    
     # Compute embeddings
     e_cand = pipeline.add_component("candidate-embedder", article_embedder, article_set=candidates)
     e_click = pipeline.add_component("history-embedder", article_embedder, article_set=clicked)
@@ -181,11 +179,18 @@ def build_pipeline(name, article_embedder, user_embedder, ranker, num_slots):
     if ranker is topk_ranker:
         o_rank = o_topk
     else:
-        o_rank = pipeline.add_component("reranker", ranker, candidate_articles=o_scored, interest_profile=e_user, theta_topic=theta_topic, theta_locality=theta_locality)
+        o_rank = pipeline.add_component(
+            "reranker",
+            ranker,
+            candidate_articles=o_scored,
+            interest_profile=e_user,
+        )
+
+    o_context = pipeline.add_component("generator", generator, clicked=e_click, recommended=o_rank)
 
     # Fallback in case not enough articles came from the ranker
     o_filtered = pipeline.add_component("topic-filter", topic_filter, candidate=candidates, interest_profile=profile)
     o_sampled = pipeline.add_component("sampler", sampler, candidate=o_filtered, backup=candidates)
-    pipeline.add_component("recommender", fill, candidates1=o_rank, candidates2=o_sampled)
+    pipeline.add_component("recommender", fill, candidates1=o_context, candidates2=o_sampled)
 
     return pipeline


### PR DESCRIPTION
This moves some code around to package it up as a `ContextGenerator` component and add it to the recommendation pipeline (instead of invoking it from the handler.)

This is the first part of a cascade of changes aimed at making the code load models fast enough to run successfully when deployed to AWS:
* Make it easier to use the `NRMSArticleEmbedder` to embed multiple text fields (in a forthcoming PR)
* Reduce the number of different language models required by replacing `all-MiniLM-L6-v2` with `NRMSArticleEmbedder` for embedding subheads
* Use those subhead embeddings in the `ContextGenerator`
* Deploy and test again