### PR TITLE
Adding support for date and pipeline splitting to generate

### DIFF
--- a/outputs/.gitignore
+++ b/outputs/.gitignore
@@ -6,3 +6,5 @@
 /mind-small-recommendations.parquet
 /mind-small-user-metrics.csv.gz
 /poprox.parquet
+/recommendations/*
+/embeddings.parquet

--- a/src/poprox_recommender/components/generators/context.py
+++ b/src/poprox_recommender/components/generators/context.py
@@ -11,9 +11,12 @@ from poprox_recommender.topics import extract_general_topics
 
 model = SentenceTransformer("all-MiniLM-L6-v2")
 
-client = OpenAI(
-    api_key="Put your key here",
-)
+dev_mode = True
+
+if not dev_mode:
+    client = OpenAI(
+        api_key="Put your key here",
+    )
 
 
 class ContextGenerator(Component):
@@ -24,11 +27,12 @@ class ContextGenerator(Component):
         self.other_filter = other_filter
 
     def __call__(self, clicked: ArticleSet, recommended: ArticleSet) -> ArticleSet:
-        for article in recommended.articles:
-            generated_subhead = generated_context(
-                article, clicked, self.time_decay, self.topk_similar, self.other_filter
-            )
-            article.subhead = generated_subhead
+        if not dev_mode:
+            for article in recommended.articles:
+                generated_subhead = generated_context(
+                    article, clicked, self.time_decay, self.topk_similar, self.other_filter
+                )
+                article.subhead = generated_subhead
 
         return recommended
 

--- a/src/poprox_recommender/evaluation/generate.py
+++ b/src/poprox_recommender/evaluation/generate.py
@@ -13,8 +13,8 @@ Options:
             write output to FILE [default: outputs/recommendations.parquet]
     -M DATA, --mind-data=DATA
             read MIND test data DATA
-    --data_path=<data_path>
-            path to PopRox data
+    -P DATA, --poprox-data=DATA
+            read POPROX test data DATA
     --subset=N
             test only on the first N test users
     --pipelines=<pipelines>...
@@ -174,12 +174,19 @@ if __name__ == "__main__":
     pipelines = options["--pipelines"]
     print("Pipelines:", pipelines)
 
-    mind_data = options["--mind-data"]
-    data_path = options["--data_path"]
-    if mind_data is not None:
-        user_recs = generate_user_recs(MindData(mind_data), pipelines, n_users)
-    elif data_path is not None:
-        user_recs = generate_user_recs(PoproxData(data_path), pipelines, n_users)
+    if options["--poprox-data"]:
+        eval_data = PoproxData(options["--poprox-data"])
+    else:
+        eval_data = MindData(options["--mind-data"])
+
+    user_recs = generate_user_recs(eval_data, pipelines, n_users)
+
+    # mind_data = options["--mind-data"]
+    # data_path = options["--data_path"]
+    # if mind_data is not None:
+    #     user_recs = generate_user_recs(MindData(mind_data), pipelines, n_users)
+    # elif data_path is not None:
+    #     user_recs = generate_user_recs(PoproxData(data_path), pipelines, n_users)
 
     all_recs = pd.concat(user_recs, ignore_index=True)
     out_fn = options["--output"]

--- a/src/poprox_recommender/evaluation/generate/__main__.py
+++ b/src/poprox_recommender/evaluation/generate/__main__.py
@@ -19,10 +19,19 @@ Options:
             use N parallel jobs
     --subset=N
             test only on the first N test profiles
+    --start_date=START_DATE
+            regenerate newsletters on and after START_DATE in the form mm/dd/yyyy
+    --end_date=END_DATE
+            regenerate newsleters before END_DATE in the form mm/dd/yyyy
+    --click_threshold=N
+            test only profiles with N clicks from start_date to end_date
+    --pipelines=<pipelines>...
+            list of pipeline names (separated by spaces)
 """
 
 import logging
 import shutil
+from datetime import datetime
 from pathlib import Path
 
 import pandas as pd
@@ -62,12 +71,29 @@ def generate_main():
     else:
         n_jobs = available_cpu_parallelism(4)
 
+    # parse start and end dates
+    start_date = None
+    end_date = None
+    if options["--start_date"]:
+        start_date = datetime.strptime(options["--start_date"], "%m/%d/%Y")
+    if options["--end_date"]:
+        end_date = datetime.strptime(options["--end_date"], "%m/%d/%Y")
+
+    # subset pipelines
+
     if options["--poprox-data"]:
-        dataset = PoproxData(options["--poprox-data"])
+        dataset = PoproxData(options["--poprox-data"], start_date, end_date)
     elif options["--mind-data"]:
         dataset = MindData(options["--mind-data"])
 
-    worker_usage = generate_profile_recs(dataset, outputs, n_profiles, n_jobs)
+    pipelines = None
+    if options["--pipelines"]:
+        pipelines = options["--pipelines"]
+        if isinstance(pipelines, str):
+            pipelines = [pipelines]
+        logger.info("generating pipelines: %s", pipelines)
+
+    worker_usage = generate_profile_recs(dataset, outputs, pipelines, n_profiles, n_jobs)
 
     logger.info("de-duplicating embeddings")
     emb_df = pd.read_parquet(outputs.emb_temp_dir)


### PR DESCRIPTION
Adding support to specify date ranges and n pipelines to generate script

python -m poprox_recommender.evaluation.generate -P POPROX --start_date 11/01/2024 --end_date 11/02/2024 --pipelines=locality-cali --jobs=1

or for multiple pipelines


python -m poprox_recommender.evaluation.generate -P POPROX --start_date 11/01/2024 --end_date 11/02/2024 --pipelines=topic-cali --pipelines=locality-cali --jobs=1