### PR TITLE
Unify Offline Evals

### DIFF
--- a/outputs/.gitignore
+++ b/outputs/.gitignore
@@ -8,3 +8,5 @@
 /poprox.parquet
 /recommendations/*
 /embeddings.parquet
+/metrics.csv
+/profile-metrics.csv.gz

--- a/src/poprox_recommender/components/diversifiers/locality_calibration.py
+++ b/src/poprox_recommender/components/diversifiers/locality_calibration.py
@@ -1,3 +1,4 @@
+import logging
 from collections import defaultdict
 
 import torch as th
@@ -9,6 +10,9 @@ from poprox_recommender.topics import extract_general_topics, extract_locality, 
 
 # Only uncomment this in offline theta value exploration
 # KL_VALUE_PATH = '/home/sun00587/research/News_Locality_Polarization/poprox-recommender-locality/outputs/theta_kl_values_11-17.txt'
+LOCALITY_DISTANCE_THRESHOLD = 0.1
+
+logger = logging.getLogger(__name__)
 
 
 class LocalityCalibrator(Component):
@@ -25,7 +29,12 @@ class LocalityCalibrator(Component):
         self,
         candidate_articles: ArticleSet,
         interest_profile: InterestProfile,
+        theta_topic: float | None,
+        theta_local: float | None,
     ) -> ArticleSet:
+        theta_topic = self.theta_topic if theta_topic is None else theta_topic
+        theta_local = self.theta_local if theta_local is None else theta_local
+
         normalized_topic_prefs = self.compute_topic_prefs(interest_profile)
         normalized_locality_prefs = self.compute_local_prefs(candidate_articles)
 
@@ -36,14 +45,16 @@ class LocalityCalibrator(Component):
 
         article_scores = article_scores.cpu().detach().numpy()
 
-        article_indices, final_calibrations = self.calibration(
-            article_scores,
-            candidate_articles.articles,
-            normalized_topic_prefs,
-            normalized_locality_prefs,
-            self.theta_topic,
-            self.theta_local,
-            topk=self.num_slots,
+        article_indices, topic_only_article_indices, final_calibrations, localities_outside_threshold = (
+            self.calibration(
+                article_scores,
+                candidate_articles.articles,
+                normalized_topic_prefs,
+                normalized_locality_prefs,
+                theta_topic,
+                theta_local,
+                topk=self.num_slots,
+            )
         )
 
         # Save computed kl divergence for topic and locality
@@ -51,9 +62,17 @@ class LocalityCalibrator(Component):
         # with open(KL_VALUE_PATH, 'a') as file:
         #     file.write('{}_top_{}_loc_{},{},{}\n'.format(str(interest_profile.profile_id), theta_topic, theta_locality, final_calibrations[0], final_calibrations[1]))
 
-        return ArticleSet(
+        article_set = ArticleSet(
             articles=[candidate_articles.articles[idx] for idx in article_indices]
         )  # all selected articles
+
+        article_set.treatment_flags = [index not in topic_only_article_indices for index in article_indices]
+        article_set.k1_topic = final_calibrations[0]
+        article_set.k1_locality = final_calibrations[1]
+
+        article_set.is_inside_locality_threshold = not localities_outside_threshold
+
+        return article_set
 
     def add_article_to_categories(self, rec_topics, article):
         rec_topics = rec_topics.copy()
@@ -86,15 +105,19 @@ class LocalityCalibrator(Component):
         # R is all candidates (not selected yet)
 
         recommendations = []  # final recommendation (topk index)
+        topic_only_recommendations = []
 
         topic_categories = defaultdict(int)
+        topic_only_categories = defaultdict(int)
         local_categories = defaultdict(int)
 
         final_calibrations = [None, None]
 
         for _ in range(topk):
             candidate = None  # next item
+            topic_candidate = None
             best_candidate_score = float("-inf")
+            best_topic_candidate_score = float("-inf")
 
             for article_idx, article_score in enumerate(relevance_scores):  # iterate R for next item
                 if article_idx in recommendations:
@@ -103,11 +126,15 @@ class LocalityCalibrator(Component):
                 normalized_candidate_topics = self.normalized_categories_with_candidate(
                     topic_categories, articles[article_idx]
                 )
+                normalized_topic_candidate_topics = self.normalized_categories_with_candidate(
+                    topic_only_categories, articles[article_idx]
+                )
                 normalized_candidate_locality = self.normalized_localities_with_candidate(
                     local_categories, articles[article_idx]
                 )
 
                 calibration_topic = compute_kl_divergence(topic_preferences, normalized_candidate_topics)
+                calibration_topic_only = compute_kl_divergence(topic_preferences, normalized_topic_candidate_topics)
                 calibration_local = compute_kl_divergence(locality_preferences, normalized_candidate_locality)
 
                 # TODO or other MOE
@@ -116,17 +143,39 @@ class LocalityCalibrator(Component):
                     - (theta_topic * calibration_topic)
                     - (theta_local * calibration_local)
                 )
+                adjusted_topic_candidate_score = (1 - theta_local - theta_topic) * article_score - (
+                    theta_topic + theta_local * calibration_topic_only
+                )
                 if adjusted_candidate_score > best_candidate_score:
                     best_candidate_score = adjusted_candidate_score
                     candidate = article_idx
                     final_calibrations = [calibration_topic, calibration_local]
+
+                if adjusted_topic_candidate_score > best_topic_candidate_score:
+                    best_topic_candidate_score = adjusted_topic_candidate_score
+                    topic_candidate = article_idx
 
             if candidate is not None:
                 recommendations.append(candidate)
                 topic_categories = self.add_article_to_categories(topic_categories, articles[candidate])
                 local_categories = self.add_article_to_localities(local_categories, articles[candidate])
 
-        return recommendations, final_calibrations
+            if topic_candidate is not None:
+                topic_only_recommendations.append(topic_candidate)
+                topic_only_categories = self.add_article_to_categories(topic_only_categories, articles[topic_candidate])
+
+        # logger.info(f"Rec'ed newsletter distribution {local_categories}")
+        # logger.info(f"Todays news  distribution {locality_preferences}")
+        normalized_local_categories = normalized_category_count(local_categories)
+        localities_outside_threshold = [
+            locality
+            for locality in normalized_local_categories
+            if locality in locality_preferences
+            and abs(normalized_local_categories[locality] - locality_preferences[locality])
+            > LOCALITY_DISTANCE_THRESHOLD
+        ]
+
+        return recommendations, topic_only_recommendations, final_calibrations, localities_outside_threshold
 
     def compute_local_prefs(self, candidate_articles: ArticleSet):
         locality_preferences: dict[str, int] = defaultdict(int)

--- a/src/poprox_recommender/components/diversifiers/locality_calibration.py
+++ b/src/poprox_recommender/components/diversifiers/locality_calibration.py
@@ -191,7 +191,8 @@ class LocalityCalibrator(Component):
 
     def compute_topic_prefs(self, interest_profile):
         topic_preferences: dict[str, int] = defaultdict(int)
-
+        # TODO uncomment to verify interest profile bug
+        # logger.info(f"Interest Profile {interest_profile.click_topic_counts}")
         for interest in interest_profile.onboarding_topics:
             topic_preferences[interest.entity_name] = max(interest.preference - 1, 0)
 

--- a/src/poprox_recommender/data/poprox.py
+++ b/src/poprox_recommender/data/poprox.py
@@ -5,11 +5,14 @@ Support for loading POPROX data for evaluation.
 # pyright: basic
 from __future__ import annotations
 
-from datetime import datetime
 import logging
-from typing import Generator
+import random
+from datetime import datetime
+from itertools import chain, product
+from typing import Generator, Tuple
 from uuid import UUID
 
+import numpy as np
 import pandas as pd
 
 from poprox_concepts import AccountInterest, Article, Click, Entity, InterestProfile, Mention
@@ -54,9 +57,16 @@ class PoproxData(EvalData):
 
         self.interests_df = interests_df
 
+        # Default to 1 for when iter_hyperparameters is never called
+        self.num_hyperparameters = 1
+
     @property
     def n_profiles(self) -> int:
         return len(self.newsletters_df["newsletter_id"].unique())
+
+    @property
+    def n_hyperparameters(self) -> int:
+        return self.num_hyperparameters
 
     @property
     def n_articles(self) -> int:
@@ -71,7 +81,59 @@ class PoproxData(EvalData):
         clicked_items = newsletter_clicks["article_id"].unique()
         return pd.DataFrame({"item": clicked_items, "rating": [1.0] * len(clicked_items)}).set_index("item")
 
-    def iter_profiles(self) -> Generator[RecommendationRequest]:
+    def iter_hyperparameters(
+        self,
+        topic_thetas: Tuple[float, float],
+        topic_theta_incr: float,
+        locality_thetas: Tuple[float, float],
+        locality_theta_incr: float,
+        random_sample: int | None = None,
+    ) -> Generator[Tuple[RecommendationRequest, Tuple[float, float]], None, None]:
+        """
+        A wrapper around iter_profiles that extends its results with combinations of topic and locality thetas.
+
+        Args:
+            topic_thetas (Tuple[float, float]): Start and end values (inclusive) for topic theta range.
+            topic_theta_incr (float): Increment for topic theta range.
+            locality_thetas (Tuple[float, float]): Start and end values (inclusive) for locality theta range.
+            locality_theta_incr (float): Increment for locality theta range.
+            random_sample (int | None): If provided, randomly sample this many points from the Cartesian product of thetas.
+
+        Yields:
+            Tuple[RecommendationRequest, Tuple[float, float]]: A recommendation request paired with theta values.
+        """
+        # Generate lists of theta values
+        topic_range = np.arange(topic_thetas[0], topic_thetas[1] + 0.01, topic_theta_incr)
+        locality_range = np.arange(locality_thetas[0], locality_thetas[1] + 0.01, locality_theta_incr)
+
+        theta_combinations = list(product(topic_range, locality_range))
+
+        logger.info(
+            f"Generated cross product of topic_theta:{topic_thetas} X locality_theta:{locality_thetas} resulting in {len(theta_combinations)} combinations"  # noqa: E501
+        )
+
+        # Select a random sample of the full combinations
+        # @mdekstrand 60 is sufficient for 95% confidence
+        if random_sample is not None and random_sample < len(theta_combinations):
+            theta_combinations = random.sample(theta_combinations, random_sample)
+            logger.info(
+                f"Down sampling to {random_sample} random combinations"  # noqa: E501
+            )
+
+        self.num_hyperparameters = len(theta_combinations)
+
+        # Extend iter_profiles to iterate over each profile with each theta combination
+        profile_iter = self.iter_profiles()
+        extended_iter = chain.from_iterable(
+            ((profile, theta) for theta in theta_combinations) for profile in profile_iter
+        )
+
+        for profile_with_theta in extended_iter:
+            yield profile_with_theta
+
+    def iter_profiles(
+        self,
+    ) -> Generator[RecommendationRequest, None, None]:
         newsletter_ids = self.newsletters_df["newsletter_id"].unique()
 
         for newsletter_id in newsletter_ids:
@@ -128,7 +190,7 @@ class PoproxData(EvalData):
                 todays_articles=candidate_articles,
                 past_articles=past_articles,
                 interest_profile=profile,
-                num_recs=TEST_REC_COUNT,
+                num_recs=TEST_REC_COUNT,  # Check to make sure None inputs are ok in the diversifier
             )
 
     def lookup_candidate_article(self, article_id: UUID):

--- a/src/poprox_recommender/evaluation/generate/__main__.py
+++ b/src/poprox_recommender/evaluation/generate/__main__.py
@@ -25,10 +25,15 @@ Options:
             regenerate newsleters before END_DATE in the form mm/dd/yyyy
     --click_threshold=N
             test only profiles with N clicks from start_date to end_date
+    --topic_thetas=TUPLE
+            test all theta values in TUPLE in the form (start, end)
+    --locality_thetas=TUPLE
+            test all theta values in TUPLE in the form (start, end)
     --pipelines=<pipelines>...
             list of pipeline names (separated by spaces)
 """
 
+import ast
 import logging
 import shutil
 from datetime import datetime
@@ -79,8 +84,14 @@ def generate_main():
     if options["--end_date"]:
         end_date = datetime.strptime(options["--end_date"], "%m/%d/%Y")
 
-    # subset pipelines
+    # Ok if None
+    topic_thetas = options["--topic_thetas"]
+    locality_thetas = options["--locality_thetas"]
 
+    topic_thetas = ast.literal_eval(topic_thetas) if topic_thetas else None
+    locality_thetas = ast.literal_eval(locality_thetas) if locality_thetas else None
+
+    # subset pipelines
     if options["--poprox-data"]:
         dataset = PoproxData(options["--poprox-data"], start_date, end_date)
     elif options["--mind-data"]:
@@ -93,7 +104,7 @@ def generate_main():
             pipelines = [pipelines]
         logger.info("generating pipelines: %s", pipelines)
 
-    worker_usage = generate_profile_recs(dataset, outputs, pipelines, n_profiles, n_jobs)
+    worker_usage = generate_profile_recs(dataset, outputs, pipelines, n_profiles, n_jobs, topic_thetas, locality_thetas)
 
     logger.info("de-duplicating embeddings")
     emb_df = pd.read_parquet(outputs.emb_temp_dir)

--- a/src/poprox_recommender/evaluation/generate/worker.py
+++ b/src/poprox_recommender/evaluation/generate/worker.py
@@ -1,6 +1,7 @@
 import itertools as it
 import logging
 import multiprocessing as mp
+from typing import Tuple
 from uuid import UUID
 
 import ipyparallel as ipp
@@ -22,6 +23,8 @@ from poprox_recommender.recommenders import recommendation_pipelines
 logger = logging.getLogger(__name__)
 
 STAGES = ["final", "ranked", "reranked"]
+
+THETA_RANDOM_SAMPLES = 60
 
 # globals used for workers
 _pipelines: dict[str, Pipeline]
@@ -55,7 +58,16 @@ def _finish_worker():
 
 
 def _generate_for_request(request: RecommendationRequest) -> UUID | None:
+    return _generate_for_hyperparamter_request((request, (None, None)))
+
+
+def _generate_for_hyperparamter_request(
+    request_with_thetas: Tuple[RecommendationRequest, Tuple[float | None, float | None]],
+) -> UUID | None:
     global _emb_seen
+
+    request = request_with_thetas[0]
+    thetas = request_with_thetas[1]
 
     logger.debug("recommending for profile %s", request.interest_profile.profile_id)
     if request.num_recs != TEST_REC_COUNT:
@@ -70,6 +82,8 @@ def _generate_for_request(request: RecommendationRequest) -> UUID | None:
         "candidate": ArticleSet(articles=request.todays_articles),
         "clicked": ArticleSet(articles=request.past_articles),
         "profile": request.interest_profile,
+        "theta_topic": thetas[0],
+        "theta_locality": thetas[1],
     }
 
     for name, pipe in _pipelines.items():
@@ -82,6 +96,8 @@ def _generate_for_request(request: RecommendationRequest) -> UUID | None:
         rec_df, embeddings = extract_recs(name, request, outputs)
         rec_df["recommender"] = pd.Categorical(rec_df["recommender"], categories=pipe_names)
         rec_df["stage"] = pd.Categorical(rec_df["stage"].astype("category"), categories=STAGES)
+        rec_df["theta_topic"] = thetas[0]
+        rec_df["theta_locality"] = thetas[1]
         _worker_out.rec_writer.write_frame(rec_df)
 
         # find any embeddings not yet written
@@ -118,6 +134,10 @@ def extract_recs(
                 "stage": "final",
                 "item": [str(a.article_id) for a in recs.articles],
                 "rank": np.arange(len(recs.articles), dtype=np.int16) + 1,
+                "treatment": False,
+                "k1_topic": -1,
+                "k1_locality": -1,
+                "is_inside_locality_threshold": None,
             }
         )
     ]
@@ -132,6 +152,10 @@ def extract_recs(
                     "stage": "ranked",
                     "item": [str(a.article_id) for a in ranked.articles],
                     "rank": np.arange(len(ranked.articles), dtype=np.int16) + 1,
+                    "treatment": False,
+                    "k1_topic": -1,
+                    "k1_locality": -1,
+                    "is_inside_locality_threshold": None,
                 }
             )
         )
@@ -146,6 +170,10 @@ def extract_recs(
                     "stage": "reranked",
                     "item": [str(a.article_id) for a in reranked.articles],
                     "rank": np.arange(len(reranked.articles), dtype=np.int16) + 1,
+                    "treatment": reranked.treatment_flags,  # type: ignore
+                    "k1_topic": reranked.k1_topic,
+                    "k1_locality": reranked.k1_locality,
+                    "is_inside_locality_threshold": reranked.is_inside_locality_threshold,
                 }
             )
         )
@@ -164,17 +192,32 @@ def extract_recs(
 
 
 def generate_profile_recs(
-    dataset: str, outs: RecOutputs, pipelines: list[str] | None = None, n_profiles: int | None = None, n_jobs: int = 1
+    dataset: str,
+    outs: RecOutputs,
+    pipelines: list[str] | None = None,
+    n_profiles: int | None = None,
+    n_jobs: int = 1,
+    topic_thetas: tuple[float, float] | None = None,
+    locality_thetas: tuple[float, float] | None = None,
 ):
     logger.info("generating recommendations")
 
-    profile_iter = dataset.iter_profiles()
+    if topic_thetas and locality_thetas:
+        profile_iter = dataset.iter_hyperparameters(
+            topic_thetas, 0.05, locality_thetas, 0.05, random_sample=THETA_RANDOM_SAMPLES
+        )
+    else:
+        profile_iter = dataset.iter_profiles()
+
     if n_profiles is None:
         n_profiles = dataset.n_profiles
         logger.info("recommending for all %d profiles", n_profiles)
     else:
         logger.info("running on subset of %d profiles", n_profiles)
         profile_iter = it.islice(profile_iter, n_profiles)
+
+    if topic_thetas and locality_thetas:
+        n_profiles = n_profiles * dataset.n_hyperparameters
 
     timer = Stopwatch()
     with make_progress(logger, "recommend", total=n_profiles) as pb:
@@ -187,7 +230,16 @@ def generate_profile_recs(
 
                 logger.debug("dispatching jobs")
                 lbv = client.load_balanced_view()
-                for uid in lbv.imap(_generate_for_request, profile_iter, max_outstanding=n_jobs * 5, ordered=False):
+                if topic_thetas and locality_thetas:
+                    request_iter = lbv.imap(
+                        _generate_for_hyperparamter_request, profile_iter, max_outstanding=n_jobs * 5, ordered=False
+                    )
+                else:
+                    request_iter = lbv.imap(
+                        _generate_for_request, profile_iter, max_outstanding=n_jobs * 5, ordered=False
+                    )
+
+                for uid in request_iter:
                     logger.debug("finished measuring %s", uid)
                     pb.update()
 
@@ -199,7 +251,10 @@ def generate_profile_recs(
             _init_worker(outs, pipelines)
 
             for request in profile_iter:
-                _generate_for_request(request)
+                if topic_thetas and locality_thetas:
+                    _generate_for_hyperparamter_request(request)
+                else:
+                    _generate_for_request(request)
                 pb.update()
 
             _finish_worker()

--- a/src/poprox_recommender/evaluation/generate/worker.py
+++ b/src/poprox_recommender/evaluation/generate/worker.py
@@ -19,6 +19,7 @@ from poprox_recommender.evaluation.generate.outputs import RecOutputs
 from poprox_recommender.lkpipeline import Pipeline
 from poprox_recommender.lkpipeline.state import PipelineState
 from poprox_recommender.recommenders import recommendation_pipelines
+from poprox_recommender.topics import user_topic_preference
 
 logger = logging.getLogger(__name__)
 
@@ -78,6 +79,12 @@ def _generate_for_hyperparamter_request(
         )
 
     pipe_names = list(_pipelines.keys())
+
+    # Calculate the clicked topic count
+    request.interest_profile.click_topic_counts = user_topic_preference(
+        request.past_articles, request.interest_profile.click_history
+    )
+
     inputs = {
         "candidate": ArticleSet(articles=request.todays_articles),
         "clicked": ArticleSet(articles=request.past_articles),

--- a/src/poprox_recommender/recommenders.py
+++ b/src/poprox_recommender/recommenders.py
@@ -168,6 +168,10 @@ def build_pipeline(name, article_embedder, user_embedder, ranker, num_slots):
     clicked = pipeline.create_input("clicked", ArticleSet)
     profile = pipeline.create_input("profile", InterestProfile)
 
+    # locality-calibration specific inputs
+    theta_topic = pipeline.create_input("theta_topic", float, None)
+    theta_locality = pipeline.create_input("theta_locality", float, None)
+
     # Compute embeddings
     e_cand = pipeline.add_component("candidate-embedder", article_embedder, article_set=candidates)
     e_click = pipeline.add_component("history-embedder", article_embedder, article_set=clicked)
@@ -184,6 +188,8 @@ def build_pipeline(name, article_embedder, user_embedder, ranker, num_slots):
             ranker,
             candidate_articles=o_scored,
             interest_profile=e_user,
+            theta_topic=theta_topic,
+            theta_locality=theta_locality,
         )
 
     o_context = pipeline.add_component("generator", generator, clicked=e_click, recommended=o_rank)


### PR DESCRIPTION
This PR introduces the iter_hyperparameters function to streamline hyperparameter tuning by generating and managing combinations of topic_theta and locality_theta values. It enhances the recommendation pipeline by supporting parallelized processing of profiles paired with these theta combinations, with an option for random sampling to reduce runtime. Additionally, it integrates key metrics for analysis and debugging.

**New Functionality:**
1. iter_hyperparameters: A generator function that yields cross-product combinations of topic_theta and locality_theta values paired with profiles.
2. Random sampling capability to reduce computational overhead (suggested by @mdekstrand).
3. Parallelization-ready structure for downstream components.

**Pipeline Integration:**
1. Added theta parameters to the rerank component.
2. Wired these parameters through the recommendation pipeline.

**Metrics Logging:**
1. KL Divergence: Measures the divergence between distributions.
2. Treatment Ratio: Tracks the ratio of profiles treated with specific configurations.
3. Within Locality Threshold Flag: Indicates compliance with locality-based constraints.