### PR TITLE
Uptake latest 'uv' changes from POPROX main

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,7 @@
     "source=${localWorkspaceFolderBasename}-pixi,target=${containerWorkspaceFolder}/.pixi,type=volume",
     "source=${localWorkspaceFolderBasename}-node_modules,target=${containerWorkspaceFolder}/node_modules,type=volume"
   ],
-  "postCreateCommand": "./.devcontainer/setup.sh",
+  "postCreateCommand": ".devcontainer/setup.sh",
   // VS Code settings
   "customizations": {
     "vscode": {


### PR DESCRIPTION
Uptake for...

 - [Switch to uv for dependency management (](https://github.com/CCRI-POPROX/poprox-recommender/commit/2e0bf8d7e083faf48edb359a9b0334f93eb725d4)https://github.com/CCRI-POPROX/poprox-recommender/pull/163[)](https://github.com/CCRI-POPROX/poprox-recommender/commit/2e0bf8d7e083faf48edb359a9b0334f93eb725d4)
 - [fix devcontainer path to work on windows](https://github.com/CCRI-POPROX/poprox-recommender/commit/716c8c408af1636d45bf88839a1e1e6431ab2d67)
 - [Add git permissions fix to devcontainer setup (](https://github.com/CCRI-POPROX/poprox-recommender/commit/f47f952dc7c86625dd87aa8701e7f7e5368e7015)https://github.com/CCRI-POPROX/poprox-recommender/pull/162[)](https://github.com/CCRI-POPROX/poprox-recommender/commit/f47f952dc7c86625dd87aa8701e7f7e5368e7015)