### PR TITLE
More specific GPT prompt, better formatting, and single newsletter API

### DIFF
--- a/src/poprox_recommender/components/generators/context.py
+++ b/src/poprox_recommender/components/generators/context.py
@@ -1,11 +1,10 @@
-import asyncio
 import json
 import logging
 from datetime import datetime, timedelta
 
 import numpy as np
 from lenskit.pipeline import Component
-from openai import AsyncOpenAI
+from openai import OpenAI
 from sentence_transformers import SentenceTransformer
 from sklearn.metrics.pairwise import cosine_similarity
 
@@ -37,7 +36,8 @@ class ContextGenerator(Component):
         self.dev_mode = dev_mode
         self.previous_context_articles = []
         if self.dev_mode:
-            self.client = AsyncOpenAI(api_key="Insert your key here.")
+            logger.info("Dev_mode is true, using live OpenAI client...")
+            self.client = OpenAI(api_key="Insert your key here...")
         self.model = SentenceTransformer(str(model_file_path("all-MiniLM-L6-v2")))
 
     def __call__(
@@ -47,17 +47,31 @@ class ContextGenerator(Component):
         interest_profile: InterestProfile,
     ) -> RecommendationList:
         if self.dev_mode:
-            selected = asyncio.run(self.generate_newsletter(clicked, selected, interest_profile))
+            selected = self.generate_newsletter(clicked, selected, interest_profile)
+            # selected = asyncio.run(self.generate_newsletter(clicked, selected, interest_profile))
         return selected
 
-    async def generate_newsletter(
+    def generate_newsletter(
         self,
         clicked: CandidateSet,
         selected: CandidateSet,
         interest_profile: InterestProfile,
     ):
         topic_distribution = LocalityCalibrator.compute_topic_prefs(interest_profile)
-        treatment = selected.treatment_flags
+        treatment_articles = []
+        treatment_map = []
+        for i, (article, treatment) in enumerate(zip(selected.articles, selected.treatment_flags)):
+            if treatment:
+                treatment_articles.append(article)
+                treatment_map.append(i)
+
+        treated_articles = self.generate_treatment_previews(
+            treatment_articles, clicked, self.time_decay, topic_distribution
+        )
+
+        for i, treated_article in enumerate(treated_articles):
+            selected.articles[treatment_map[i]] = treated_article
+        """
         tasks = []
 
         for i in range(len(selected.articles)):
@@ -73,45 +87,95 @@ class ContextGenerator(Component):
                 logger.error(f"Error generating context for article: {result}")
             else:
                 article.headline, article.subhead = result
-
+        """
         return selected
 
-    async def generated_context(
+    def generate_treatment_previews(
         self,
-        article: Article,
+        articles: list[Article],
         clicked_articles: CandidateSet,
         time_decay: bool,
         topic_distribution: dict,
     ):
-        related_article = self.related_context(article, clicked_articles, time_decay)
+        system_prompt = (
+            "You are an Associated Press editor tasked to rewrite a list of news article previews in a natural "
+            "and factual tone. You are provided multiple [[MAIN_NEWS]] each with a HEADLINE and SUB_HEADLINE "
+            "that should be rewritten using the following rules based on [[RELATED_NEWS]] or [[INTERESTED_TOPICS]]. "
+            "Your response should only include a JSON list parseable by json.loads() in the "
+            '\'{"REWRITTEN_ARTICLES": [{"HEADLINE": "[REWRITTEN_HEADLINE]", "SUB_HEADLINE": "[REWRITTEN_SUBHEADLINE]"}]}\' '  # noqa: E501
+            "and should include a rewritten HEADLINE and SUB_HEADLINE for each [[MAIN_NEWS]] article in the input. "
+            "Rules for rewritting [[MAIN_NEWS]] with [[RELATED_NEWS]]: "
+            # "1. ***The rewritten news preview should explicitly name and reference parts of the HEADLINE of the [[RELATED_NEWS]].*** "  # noqa: E501
+            "1. ***Explicitly integrate key themes or implications from the [[RELATED_NEWS]] headline into the "
+            "rewritten news preview, rather than just naming or referencing it. The connection should feel meaningful, "
+            "not just mentioned in passing.*** "
+            "2. Reframe the [[MAIN_NEWS]] headline to emphasize a natural progression, contrast, or deeper context "
+            "related to the [[RELATED_NEWS]]. Highlight how the new article builds on, challenges, or expands the "
+            "reader's prior understanding."
+            "3. Avoid minimal rewording of the original [[MAIN_NEWS]] headline—introduce a fresh angle that makes the "
+            "connection to [[RELATED_NEWS]] feel insightful and engaging."
+            # "2. The rewritten news preview should highlight points that are relevant to why the user should also be "
+            # "interested in [[MAIN_NEWS]] based on the fact they previously read [[RELATED_NEWS]]. "
+            "Rules for rewritting [[MAIN_NEWS]] with [[INTERESTED_TOPICS]]: "
+            "1. ***Explicitly integrate one or more of the user's broad [[INTERESTED_TOPICS]] into the rewritten news "
+            "preview in a way that naturally reshapes the focus of the headline.*** "
+            # "1. ***The rewritten news preview should explicitly name and connect the user's broad [[INTERESTED_TOPICS]] to [[MAIN_NEWS]].*** "  # noqa: E501
+            "2. Reframe the original headline to emphasize an angle that directly appeals to why the user's "
+            "[[INTERESTED_TOPICS]] make this news particularly relevant. Instead of merely linking the topics, adjust "
+            "the framing to highlight an unexpected connection, unique insight, or compelling consequence."
+            "3. Avoid simply restating the original [[MAIN_NEWS]] headline with minor adjustments; instead, introduce "
+            "a fresh perspective that aligns with the user's interests while remaining true to the core facts."
+            # "3. The rewritten news preview should highlight points that are relevant to why the user should also be "
+            # "interested in [[MAIN_NEWS]] based on the user's top [[INTERESTED_TOPICS]]. "
+            "Rules for all rewritten previews:"
+            "1. All rewritten previews should have a HEADLINE and SUB_HEADLINE."
+            "2. All [REWRITTEN_SUBHEADLINE]s shouldn't end in punctuation. "
+            "3. All [REWRITTEN_HEADLINE]s and [REWRITTEN_SUBHEADLINE]s should be approximately the same length as the "
+            "[[MAIN_NEWS]] HEADLINE and SUB_HEADLINE they are based on. "
+            "4. Ensure that words and strategies used to highlight relevant points in the rewritten previews are "
+            "different from one another in the resulting list. "
+            "5. Ensure all rewritten articles are neutral and accurately describe the [[MAIN_NEWS]] they are based on."
+        )
 
-        if related_article is not None:
-            # high similarity, use the top-1 article to rewrite the rec
-            main_news = {"HEADING": article.headline, "SUB_HEADING": article.subhead}
-            related_news = {
-                "HEADING": related_article.headline,
-                "SUB_HEADING": related_article.subhead,
-            }
+        input_prompt = []
+        sorted_topics = sorted(topic_distribution.items(), key=lambda item: item[1], reverse=True)
+        top_topics = [key for key, _ in sorted_topics[:NUM_TOPICS]]
 
-            generated_rec = await self.semantic_narrative(main_news, related_news)
+        rewritten_article_mapping = []
+        logger.info(f"Top {NUM_TOPICS} topics: {top_topics}")
+        for i, article in enumerate(articles):
+            related_article = self.related_context(article, clicked_articles, time_decay)
+            if related_article is not None:
+                # high similarity, use the top-1 article to rewrite the rec
+                article_prompt = f"[[MAIN_NEWS]]\nHEADLINE: {article.headline}\nSUB_HEADLINE: {article.subhead}\n[[RELATED_NEWS]]\nHEADLINE: {related_article.headline}\nSUB_HEADLINE: {related_article.subhead}"  # noqa: E501
 
-        else:
-            if topic_distribution:
-                generated_rec = await self.highlevel_narrative(article, topic_distribution)
+                logger.info(
+                    f"Generating event-level narrative for '{article.headline[:15]}' from related article {related_article.headline[:15]}"  # noqa: E501
+                )
+                input_prompt.append(article_prompt)
+                rewritten_article_mapping.append(i)
             else:
-                generated_rec = {
-                    "HEADLINE": article.headline,
-                    "SUB_HEADLINE": article.subhead,
-                }
+                if topic_distribution:
+                    article_prompt = f"[[MAIN_NEWS]]\nHEADLINE: {article.headline}\nSUB_HEADLINE: {article.subhead}\n[[INTERESTED_TOPICS]]\n{top_topics}"  # noqa: E501
 
-        generated_dict = json.loads(generated_rec)
-        generated_headline = generated_dict.get("HEADLINE", "")
-        generated_subhead = generated_dict.get("SUB_HEADLINE", "")
-        if generated_headline == "" or generated_subhead == "":
-            logger.warning("GPT response invald, falling back to original headline...")
-            return article.headline, article.subhead
-        else:
-            return generated_headline, generated_subhead
+                    logger.info(f"Generating topic-level narrative for related article: {article.headline[:15]}")
+                    input_prompt.append(article_prompt)
+                    rewritten_article_mapping.append(i)
+                else:
+                    logger.warning(
+                        f"No topic_distribution for generating high-level narrative for {article.headline[:15]}. Falling back to original preview..."  # noqa: E501
+                    )
+        try:
+            rewritten_previews = self.gpt_generate(system_prompt, input_prompt, len(rewritten_article_mapping))
+        except Exception as e:
+            logger.error(f"Error in call to OPENAI API: {e}. Falling back to all original preview...")
+            return articles
+
+        for i, rewritten_preview in enumerate(rewritten_previews):
+            articles[rewritten_article_mapping[i]].headline = rewritten_preview["HEADLINE"]
+            articles[rewritten_article_mapping[i]].subhead = rewritten_preview["SUB_HEADLINE"]
+
+        return articles
 
     def related_context(
         self,
@@ -176,79 +240,95 @@ class ContextGenerator(Component):
             return selected_indices
 
         else:
-            selected_indices = np.argsort(weighted_similarities)[-1:]
+            selected_indices = np.argsort(similarities)[-1:]
             return selected_indices
-
-    async def semantic_narrative(self, main_news, related_news):
-        system_prompt = (
-            "You are an Associated Press editor tasked to rewrite the [[MAIN_NEWS]] HEADING and SUB_HEADING in a natural and factual tone. "  # noqa: E501
-            "You are provided a [[MAIN_NEWS]] to be recommended and a [[RELATED_NEWS]] that a user read before. "
-            "Rewrite the HEADLINE and SUB_HEADLING of [[MAIN_NEWS]] by implicitly connecting it to [[RELATED_NEWS]] and "  # noqa: E501
-            "highlight points from [[RELATED_NEWS]] relevant to why the user should also be interested in [[MAIN_NEWS]]. "  # noqa: E501
-            'Your response should only include JSON parsable by json.loads() in the format {"HEADLINE": "[REWRITTEN_HEADLINE]", "SUB_HEADLINE": "[REWRITTEN_SUBHEADLINE]"}\'. '  # "Your response should only include a rewritten healdine and subheadling always in the form '##HEADLINE##: [REWRITTEN_HEADLINE] ##SUB_HEADLINE##: [REWRITTEN_SUBHEADLINE]' "  # noqa: E501
-            "[REWRITTEN_HEADLINE] should be 15 or less words and [REWRITTEN_SUBHEADLINE] should be a single sentence, "
-            "no more than 30 words, and shouldn't end in punctuation. Ensure both are neutral and accurately describe [[MAIN_NEWS]]."  # noqa: E501
-        )
-
-        input_prompt = f"[[MAIN_NEWS]]: {main_news} \n[[RELATED_NEWS]]: {related_news}"
-
-        logger.info(f"Semantic narrative: {input_prompt}")
-        return await self.gpt_generate(system_prompt, input_prompt)
-
-    async def highlevel_narrative(self, main_news, topic_distribution):
-        logger.info(f"Topic distribution narrative: {topic_distribution}")
-        sorted_items = sorted(topic_distribution.items(), key=lambda item: item[1], reverse=True)
-        top_keys = [key for key, _ in sorted_items[:NUM_TOPICS]]
-
-        system_prompt = (
-            "You are an Associated Press editor tasked to rewrite the [[MAIN_NEWS]] HEADING and SUB_HEADING in a natural and factual tone. "  # noqa: E501
-            "You are provided a [[MAIN_NEWS]] to be recommended to a user interested in [[INTERESTED_TOPICS]]."
-            "Rewrite the HEADLINE and SUB_HEADLING of [[MAIN_NEWS]] by implicitly connecting it to [[INTERESTED_TOPICS]] "  # noqa: E501
-            "and highlight points relevant to why the user should also be interested in [[MAIN_NEWS]]. "
-            'Your response should only include JSON parsable by json.loads() in the format {"HEADLINE": "[REWRITTEN_HEADLINE]", "SUB_HEADLINE": "[REWRITTEN_SUBHEADLINE]"}\'. '  # a rewritten healdine and subheadling always in the form '##HEADLINE##: [REWRITTEN_HEADLINE] ##SUB_HEADLINE##: [REWRITTEN_SUBHEADLINE]' "  # noqa: E501
-            "[REWRITTEN_HEADLINE] should be 15 or less words and [REWRITTEN_SUBHEADLINE] should be a single sentence, "
-            "no more than 30 words, and shouldn't end in punctuation. Ensure both are neutral and accurately describe [[MAIN_NEWS]]."  # noqa: E501
-        )
-
-        main_news = {"HEADING": main_news.headline, "SUB_HEADING": main_news.subhead}
-        input_prompt = f"[[MAIN_NEWS]]: {main_news} \n[[INTERESTED_TOPICS]]: {top_keys}"
-
-        logger.info(f"Highlevel narrative: {input_prompt}")
-        return await self.gpt_generate(system_prompt, input_prompt)
 
     def get_time_weight(self, published_target, published_clicked):
         time_distance = abs((published_clicked - published_target).days)
         weight = 1 / np.log(1 + time_distance) if time_distance > 0 else 1  # Avoid log(1) when x = 0
         return weight
 
-    async def gpt_generate(self, system_prompt, content_prompt):
-        retries = 0
+    def rewritten_previews_feedback(self, rewritten_previews, expected_output_n):
+        if not isinstance(rewritten_previews, dict) and "REWRITTEN_ARTICLES" not in rewritten_previews:
+            logger.warning("GPT response invald and doesn't contain a list of previews. Retrying...")
+            feedback = (
+                "Your response isn't a JSON list parseable by json.loads() in the "
+                'format \'[{"HEADLINE": "[REWRITTEN_HEADLINE]", "SUB_HEADLINE": "[REWRITTEN_SUBHEADLINE]"}]\' '
+                "and should include a rewritten HEADLINE and SUB_HEADLINE for each article in the list of "
+                "[[MAIN_NEWS]]. Ensure your response is a valid JSON list parseable by json.loads() that "
+                f"includes all {expected_output_n} rewritten articles."
+            )
+            return feedback
+        elif len(rewritten_previews["REWRITTEN_ARTICLES"]) != expected_output_n:
+            logger.warning(
+                f"GPT response invald and is missing previews {len(rewritten_previews['REWRITTEN_ARTICLES'])} != {expected_output_n}. Retrying..."  # noqa: E501
+            )
+            feedback = (
+                f"Your response JSON list of rewritten headlines doesn't include all {expected_output_n} "
+                "rewritten articles. Ensure your response is a valid JSON list parseable by json.loads() that "
+                f"includes all {expected_output_n} rewritten articles."
+            )
+            return feedback
+        for item in rewritten_previews["REWRITTEN_ARTICLES"]:
+            if not isinstance(item, dict) or set(item.keys()) != {"HEADLINE", "SUB_HEADLINE"}:
+                logger.warning(f"GPT response invald for {item}. Retrying...")
+                feedback = (
+                    "Your response includes one or more articles not in the format "
+                    '\'{"HEADLINE": "[REWRITTEN_HEADLINE]", "SUB_HEADLINE": "[REWRITTEN_SUBHEADLINE]"}\'. '
+                    f"Ensure all {expected_output_n} rewritten articles contain both a HEADLINE and SUB_HEADLINE "
+                    "and are included in a JSON list parseable by json.loads() in the "
+                    'format \'[{"HEADLINE": "[REWRITTEN_HEADLINE]", "SUB_HEADLINE": "[REWRITTEN_SUBHEADLINE]"}]\' '
+                )
+                return feedback
+
+        return False
+
+    def gpt_generate(self, system_prompt, content_prompt, expected_output_n):
         message = [
-            {"role": "system", "content": system_prompt},
-            {"role": "user", "content": content_prompt},
+            {"role": "system", "content": [{"type": "text", "text": system_prompt}]},
+            {"role": "user", "content": [{"type": "text", "text": main_news} for main_news in content_prompt]},
         ]
         temperature = 0.2
-        max_tokens = 256
+        max_tokens = 2000
         frequency_penalty = 0.0
+        chat_completion = self.client.beta.chat.completions.parse(
+            messages=message,
+            response_format={"type": "json_object"},
+            temperature=temperature,
+            max_tokens=max_tokens,
+            frequency_penalty=frequency_penalty,
+            model="gpt-4o",
+        )
+        logger.info(f"GPT response: {chat_completion.choices[0].message.content}")
 
-        while retries < MAX_RETRIES:
-            try:
-                chat_completion = await self.client.beta.chat.completions.parse(
-                    messages=message,
-                    response_format={"type": "json_object"},
-                    temperature=temperature,
-                    max_tokens=max_tokens,
-                    frequency_penalty=frequency_penalty,
-                    model="gpt-4o-mini",
-                )
-                logger.info(f"GPT response: {chat_completion.choices[0].message.content}")
-                return chat_completion.choices[0].message.content
+        rewritten_previews = json.loads(chat_completion.choices[0].message.content)
+        feedback = self.rewritten_previews_feedback(rewritten_previews, expected_output_n)
+        if feedback:
+            logger.warning(f"GPT response invalid. Retrying with feedback '{feedback}'")
+            reprompt_message = [
+                {"role": "system", "content": [{"type": "text", "text": system_prompt}]},
+                {"role": "user", "content": [{"type": "text", "text": main_news} for main_news in content_prompt]},
+                {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": chat_completion.choices[0].message.content}],
+                },
+                {"role": "user", "content": [{"type": "text", "text": feedback}]},
+            ]
 
-            except Exception as e:
-                print(f"Fail to call OPENAI API: {e}")
-                retries += 1
-                if retries < MAX_RETRIES:
-                    print(f"{retries} try to regenerate the context")
-                    await asyncio.sleep(DELAY)
-                else:
-                    raise
+            chat_completion = self.client.beta.chat.completions.parse(
+                messages=reprompt_message,
+                response_format={"type": "json_object"},
+                temperature=temperature,
+                max_tokens=max_tokens,
+                frequency_penalty=frequency_penalty,
+                model="gpt-4o",
+            )
+
+            logger.info(f"GPT reprompt response: {chat_completion.choices[0].message.content}")
+            rewritten_previews = json.loads(chat_completion.choices[0].message.content)
+
+            feedback = self.rewritten_previews_feedback(rewritten_previews, expected_output_n)
+            if feedback:
+                raise ValueError(f"GPT response still invalid. Failing from feedback '{feedback}'")
+
+        return rewritten_previews["REWRITTEN_ARTICLES"]


### PR DESCRIPTION
This PR also introduces "smart" feedback retries. This pattern can be used to give feedback about metrics we care about if we implement them live.

Tested this code with a large and medium request body. Notebook tests with the same prompt but a more curated set of news, related news, topics produces better results.

Things we should continue to monitor:
1. Conisder breaking the GPT call into two ASYNC requests to balance improved quality of individual articles with the desire for variance between previews
2. Through thorough testing of this code, it became clear how important logs during testing will be. Specifically, I'm concerned about the threshold for similarity and the uncertainty we have about how often (if ever) event-level rewrites will trigger. With logging next week, we should track the number of treatments of each type that are applied and the max similarity score of articles irrespective of the type of treatment we apply.