### PR TITLE
Support for regenerating locality experiment for calibration group

### DIFF
--- a/src/poprox_recommender/components/generators/context.py
+++ b/src/poprox_recommender/components/generators/context.py
@@ -172,7 +172,7 @@ class ContextGeneratorConfig(BaseModel):
 class ContextGenerator(Component):
     config: ContextGeneratorConfig
 
-    def __init__(self, time_decay=True, is_gpt_live=True):
+    def __init__(self, time_decay=True, is_gpt_live=False):
         self.time_decay = time_decay
         self.is_gpt_live = is_gpt_live
 

--- a/src/poprox_recommender/data/poprox.py
+++ b/src/poprox_recommender/data/poprox.py
@@ -306,9 +306,7 @@ def load_poprox_frames(archive: str = "POPROX", start_date: datetime | None = No
     data = project_root() / "data"
     logger.info("loading POPROX data from %s", archive)
 
-    newsletters_df = pd.read_parquet(
-        data / "POPROX" / "experiment-0fc61eca-fca7-4914-9ea0-bc29ed2e0ad1" / "newsletters_20250717-194301.parquet"
-    )
+    newsletters_df = pd.read_parquet(data / archive / "newsletters.parquet")
     newsletters_df["created_at_date"] = pd.to_datetime(newsletters_df["created_at"])
 
     if start_date:
@@ -318,49 +316,17 @@ def load_poprox_frames(archive: str = "POPROX", start_date: datetime | None = No
         logger.info("loading newsleters before %s", end_date)
         newsletters_df = newsletters_df[newsletters_df["created_at_date"] < end_date]
 
-    articles_df = pd.read_parquet(
-        data
-        / "POPROX"
-        / "experiment-0fc61eca-fca7-4914-9ea0-bc29ed2e0ad1"
-        / "candidate"
-        / "articles_20250717-194309.parquet"
-    )
-    mentions_df = pd.read_parquet(
-        data
-        / "POPROX"
-        / "experiment-0fc61eca-fca7-4914-9ea0-bc29ed2e0ad1"
-        / "candidate"
-        / "article_mentions_20250717-194310.parquet"
-    )
+    articles_df = pd.read_parquet(data / archive / "candidate" / "articles.parquet")
+    mentions_df = pd.read_parquet(data / archive / "candidate" / "article_mentions.parquet")
 
-    clicks_df = pd.read_parquet(
-        data / "POPROX" / "experiment-0fc61eca-fca7-4914-9ea0-bc29ed2e0ad1" / "clicks_20250717-194312.parquet"
-    )
-    clicked_articles_df = pd.read_parquet(
-        data
-        / "POPROX"
-        / "experiment-0fc61eca-fca7-4914-9ea0-bc29ed2e0ad1"
-        / "clicked"
-        / "articles_20250717-194314.parquet"
-    )
-    clicked_mentions_df = pd.read_parquet(
-        data
-        / "POPROX"
-        / "experiment-0fc61eca-fca7-4914-9ea0-bc29ed2e0ad1"
-        / "clicked"
-        / "article_mentions_20250717-194315.parquet"
-    )
+    clicks_df = pd.read_parquet(data / archive / "clicks.parquet")
+    clicked_articles_df = pd.read_parquet(data / archive / "clicked" / "articles.parquet")
+    clicked_mentions_df = pd.read_parquet(data / archive / "clicked" / "article_mentions.parquet")
 
-    interests_df = pd.read_parquet(
-        data / "POPROX" / "experiment-0fc61eca-fca7-4914-9ea0-bc29ed2e0ad1" / "interests_20250717-194159.parquet"
-    )
+    interests_df = pd.read_parquet(data / archive / "interests.parquet")
 
-    experiment_df = pd.read_parquet(
-        data / "POPROX" / "experiment-0fc61eca-fca7-4914-9ea0-bc29ed2e0ad1" / "experiment_20250717-194157.parquet"
-    )
-    assignments_df = pd.read_parquet(
-        data / "POPROX" / "experiment-0fc61eca-fca7-4914-9ea0-bc29ed2e0ad1" / "assignments_20250717-194157.parquet"
-    )
+    experiment_df = pd.read_parquet(data / archive / "experiment.parquet")
+    assignments_df = pd.read_parquet(data / archive / "assignments.parquet")
 
     return (
         articles_df,

--- a/src/poprox_recommender/data/poprox.py
+++ b/src/poprox_recommender/data/poprox.py
@@ -207,25 +207,26 @@ class PoproxData(EvalData):
             profile_clicks_df = self.clicks_df.loc[self.clicks_df["profile_id"] == profile_id]
             logger.info(profile_clicks_df.columns)
             filtered_clicks_df = profile_clicks_df[profile_clicks_df["clicked_at"] < newsletter_created_at]
-            if len(filtered_clicks_df) == 0:
-                logger.warning(f"No clicks for profile {profile_id} before newsletter {newsletter_id}")
-                continue
+            # if len(filtered_clicks_df) == 0:
+            #     logger.warning(f"No clicks for profile {profile_id} before newsletter {newsletter_id}")
+            #     continue
 
             # Create Article and Click objects from dataframe rows
             clicks = []
             past_articles = []
-            for article_row in filtered_clicks_df.itertuples():
-                article = self.lookup_clicked_article(article_row.article_id)
-                if article:
-                    past_articles.append(article)
+            if len(filtered_clicks_df) > 0:
+                for article_row in filtered_clicks_df.itertuples():
+                    article = self.lookup_clicked_article(article_row.article_id)
+                    if article:
+                        past_articles.append(article)
 
-                    clicks.append(
-                        Click(
-                            article_id=article_row.article_id,
-                            newsletter_id=article_row.newsletter_id,
-                            timestamp=article_row.clicked_at,
+                        clicks.append(
+                            Click(
+                                article_id=article_row.article_id,
+                                newsletter_id=article_row.newsletter_id,
+                                timestamp=article_row.clicked_at,
+                            )
                         )
-                    )
 
             interests = self.interests_df.loc[self.interests_df["account_id"] == profile_id]
             topics = []

--- a/src/poprox_recommender/evaluation/generate.py
+++ b/src/poprox_recommender/evaluation/generate.py
@@ -128,8 +128,8 @@ def generate_user_recs(data: EvalData, pipe_names: list[str] | None = None, n_us
 
     timer = Stopwatch()
     with make_progress(logger, "recommend", total=data.n_profiles * 4) as pb:
-        for request in user_iter:  # one by one
-            logger.debug("recommending for user %s", request.interest_profile.profile_id)
+        for (request), newsletter_id in user_iter:  # one by one
+            logger.info("recommending for user %s", request.interest_profile.profile_id)
             if request.num_recs != TEST_REC_COUNT:
                 logger.warn(
                     "request for %s had unexpected recommendation count %d",
@@ -150,6 +150,8 @@ def generate_user_recs(data: EvalData, pipe_names: list[str] | None = None, n_us
                 user_df = extract_recs(name, request, outputs)
                 user_df["recommender"] = pd.Categorical(user_df["recommender"], categories=pipe_names)
                 user_df["stage"] = pd.Categorical(user_df["stage"].astype("category"), categories=STAGES)
+                user_df["profile_id"] = str(request.interest_profile.profile_id)
+                user_df["newsletter_id"] = str(newsletter_id)
                 user_recs.append(user_df)
             pb.update()
 

--- a/src/poprox_recommender/evaluation/generate/worker.py
+++ b/src/poprox_recommender/evaluation/generate/worker.py
@@ -79,8 +79,8 @@ def _finish_worker():
         return None
 
 
-def _generate_for_request(request: RecommendationRequestV2) -> UUID | None:
-    return _generate_for_hyperparamter_request((request, (None, None)))
+def _generate_for_request(request: Tuple[RecommendationRequestV2, str]) -> UUID | None:
+    return _generate_for_hyperparamter_request((request[0], (None, None), request[1]))
 
 
 def _generate_for_hyperparamter_request_threshold(
@@ -144,12 +144,13 @@ def _generate_for_hyperparamter_request_threshold(
 
 
 def _generate_for_hyperparamter_request(
-    request_with_thetas: Tuple[RecommendationRequestV2, Tuple[float | None, float | None]],
+    request_with_thetas: Tuple[RecommendationRequestV2, Tuple[float | None, float | None], str],
 ) -> UUID | None:
     global _emb_seen
 
     request = request_with_thetas[0]
     thetas = request_with_thetas[1]
+    newsletter_id = request_with_thetas[2]
 
     logger.debug("recommending for profile %s", request.interest_profile.profile_id)
     if request.num_recs != TEST_REC_COUNT:
@@ -188,6 +189,7 @@ def _generate_for_hyperparamter_request(
         rec_df["similarity_threshold"] = ContextGeneratorConfig().similarity_threshold
         rec_df["theta_topic"] = thetas[0]
         rec_df["theta_locality"] = thetas[1]
+        rec_df["newsletter_id"] = newsletter_id
         _worker_out.rec_writer.write_frame(rec_df)
 
         # find any embeddings not yet written

--- a/src/poprox_recommender/recommenders/load.py
+++ b/src/poprox_recommender/recommenders/load.py
@@ -106,4 +106,5 @@ def load_all_pipelines(device: str | None = None, num_slots: int = 10) -> dict[s
     logger.debug("loading all pipelines")
 
     names = discover_pipelines()
+    logger.info("discovered pipelines", count=len(names), names=names)
     return {n: get_pipeline(n, device, num_slots) for n in names}


### PR DESCRIPTION
Steps:

1. Add data extract to data folder (should have clicked and candidate directories for articles and article mentions). Also, the code expects file names in the form article.parquet, experiment.parquet, etc. (no unique identifies).
2. Launch dev container
3. `Run python -m poprox_recommender.evaluation.generate -P [Path to extract inside /data] --pipelines=locality_cali_context --jobs=1`

Outputs:

The above command will generate a parquet (or multiple if jobs>1) in the outputs/recommendation directory. To validate successful duplication, outputs can be compared to `newsletters_20250717-194301.parquet`, joining on newsletter_id. article_id/item_id, and position/rank, which should produce 16080 rows.

Example: `Run python -m poprox_recommender.evaluation.generate -P POPROX/experiment --pipelines=locality_cali_context --jobs=1`